### PR TITLE
Avoid GCC warning about printing a Window (long) as an int

### DIFF
--- a/xseticon.c
+++ b/xseticon.c
@@ -309,7 +309,7 @@ int main(int argc, char* argv[])
   }
 
   if (verbose)
-    printf("Have selected window 0x%08x\n", window);
+    printf("Have selected window 0x%08lx\n", window);
 
   Atom property = XInternAtom(display, "_NET_WM_ICON", 0);
 


### PR DESCRIPTION
Building xseticon on Ubuntu 18.04 (amd64), I noticed the following warning:

```
xseticon.c: In function ‘main’:
xseticon.c:312:39: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘Window {aka long unsigned int}’ [-Wformat=]
     printf("Have selected window 0x%08x\n", window);
                                    ~~~^
                                    %08lx
```

This just cleans that up.