### PR TITLE
Enable window selection based on WM_CLASS hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Usage
 =====
     usage: xseticon [options] path/to/icon.png
     options:
-      -name     : apply icon to the window of the name supplied
-      -id   : apply icon to the window id supplied
+      -name  : apply icon to the window of the name supplied
+      -id    : apply icon to the window id supplied
+      -class : apply icon to the window matching the class supplied
+
     
     Sets the window icon to the specified .png image. The image is loaded from
     the file at runtime and sent to the X server; thereafter the file does not

--- a/xseticon.c
+++ b/xseticon.c
@@ -47,6 +47,7 @@ void usage(int exitcode)
   printf("options:\n");
   printf("  -name <text>    : apply icon to the window of the name supplied\n");
   printf("  -id <windowid>  : apply icon to the window id supplied\n");
+  printf("  -class <text>   : apply icon to the window matching the class supplied\n");
   printf("\n");
   printf("Sets the window icon to the specified .png image. The image is loaded from\n");
   printf("the file at runtime and sent to the X server; thereafter the file does not\n");
@@ -99,6 +100,30 @@ Window Window_With_Name(Display* dpy, Window top, char* name)
   return(w);
 }
 
+Window Window_With_Class(Display* dpy, Window top, char* class)
+{
+  Window *children, dummy;
+  unsigned int nchildren;
+  int i;
+  Window w = 0;
+  XClassHint *hint = XAllocClassHint();
+
+  if (XGetClassHint(dpy, top, hint)
+      && (!strcmp(hint->res_class, class) || !strcmp(hint->res_name, class)))
+    return(top);
+
+  if (!XQueryTree(dpy, top, &dummy, &dummy, &children, &nchildren))
+    return(0);
+
+  for (i=0; i<nchildren; i++) {
+          w = Window_With_Class(dpy, children[i], class);
+          if (w)
+            break;
+  }
+  if (children) XFree ((char *)children);
+  return(w);
+}
+
 Window Select_Window_Args(Display* dpy, int screen, int* rargc, char* argv[])
 {
   int nargc = 1;
@@ -128,6 +153,16 @@ Window Select_Window_Args(Display* dpy, int screen, int* rargc, char* argv[])
                            OPTION);
       if (!w)
         Fatal_Error("No window with name %s exists!",OPTION);
+      continue;
+    }
+    if (!strcmp(OPTION, "-class")) {
+      NXTOPT;
+      if (verbose)
+        printf("Selecting window by class %s\n", OPTION);
+      w = Window_With_Class(dpy, RootWindow(dpy, screen),
+                            OPTION);
+      if (!w)
+        Fatal_Error("No window with class %s exists!",OPTION);
       continue;
     }
     if (!strcmp(OPTION, "-id")) {


### PR DESCRIPTION
This change takes into account both the instance and class names to return the first matching window.